### PR TITLE
Turn on Wpedantic.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(pcl_conversions)
 
 if(NOT WIN32)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -Wpedantic")
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/test/test_pcl_conversions.cpp
+++ b/test/test_pcl_conversions.cpp
@@ -50,12 +50,12 @@ protected:
 template<class T>
 void test_image(T &image) {
   EXPECT_EQ(std::string("pcl"), image.header.frame_id);
-  EXPECT_EQ(1, image.height);
-  EXPECT_EQ(2, image.width);
-  EXPECT_EQ(1, image.step);
+  EXPECT_EQ(1U, image.height);
+  EXPECT_EQ(2U, image.width);
+  EXPECT_EQ(1U, image.step);
   EXPECT_TRUE(image.is_bigendian);
   EXPECT_EQ(std::string("bgr8"), image.encoding);
-  EXPECT_EQ(2, image.data.size());
+  EXPECT_EQ(2U, image.data.size());
   EXPECT_EQ(0x42, image.data[0]);
   EXPECT_EQ(0x43, image.data[1]);
 }
@@ -71,21 +71,21 @@ TEST_F(PCLConversionTests, imageConversion) {
 template<class T>
 void test_pc(T &pc) {
   EXPECT_EQ(std::string("pcl"), pc.header.frame_id);
-  EXPECT_EQ(1, pc.height);
-  EXPECT_EQ(2, pc.width);
-  EXPECT_EQ(1, pc.point_step);
-  EXPECT_EQ(1, pc.row_step);
+  EXPECT_EQ(1U, pc.height);
+  EXPECT_EQ(2U, pc.width);
+  EXPECT_EQ(1U, pc.point_step);
+  EXPECT_EQ(1U, pc.row_step);
   EXPECT_TRUE(pc.is_bigendian);
   EXPECT_TRUE(pc.is_dense);
   EXPECT_EQ("XYZ", pc.fields[0].name);
   EXPECT_EQ(pcl::PCLPointField::INT8, pc.fields[0].datatype);
-  EXPECT_EQ(3, pc.fields[0].count);
-  EXPECT_EQ(0, pc.fields[0].offset);
+  EXPECT_EQ(3U, pc.fields[0].count);
+  EXPECT_EQ(0U, pc.fields[0].offset);
   EXPECT_EQ("RGB", pc.fields[1].name);
   EXPECT_EQ(pcl::PCLPointField::INT8, pc.fields[1].datatype);
-  EXPECT_EQ(3, pc.fields[1].count);
-  EXPECT_EQ(8 * 3, pc.fields[1].offset);
-  EXPECT_EQ(2, pc.data.size());
+  EXPECT_EQ(3U, pc.fields[1].count);
+  EXPECT_EQ(8U * 3U, pc.fields[1].offset);
+  EXPECT_EQ(2U, pc.data.size());
   EXPECT_EQ(0x42, pc.data[0]);
   EXPECT_EQ(0x43, pc.data[1]);
 }


### PR DESCRIPTION
This also seems to cause the tests to start complaining about
a signed/unsigned mismatch, so fix that here as well.

connects to ros2/ros2#342

CI:
* TB2 Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux&build=30)](http://ci.ros2.org/job/ci_turtlebot-demo_linux/30/)
* TB2 Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux-aarch64&build=44)](http://ci.ros2.org/job/ci_turtlebot-demo_linux-aarch64/44/)